### PR TITLE
fix: fix bug about static_assert

### DIFF
--- a/src/muda/viewer/dense/dense_1d.h
+++ b/src/muda/viewer/dense/dense_1d.h
@@ -58,7 +58,7 @@ class Dense1DT : public ViewerBase<IsConst>
         : m_data(other.data())
         , m_dim(other.dim())
     {
-        static_assert(OtherIsConst, "Only non-const viewer can be convert to const viewer"); // TODO: failed at CUDA 13
+        static_assert(!OtherIsConst, "Only non-const viewer can be convert to const viewer"); // TODO: failed at CUDA 13
     }
 
     MUDA_GENERIC auto as_const() const MUDA_NOEXCEPT


### PR DESCRIPTION
```
/home/ps/Projects/muda/src/muda/viewer/dense/dense_1d.h(61): error: static assertion failed with "Only non-const viewer can be convert to const viewer"
          static_assert(OtherIsConst, "Only non-const viewer can be convert to const viewer");
          ^
          detected during:
            instantiation of "muda::Dense1DT<IsConst, T>::Dense1DT(const muda::Dense1DT<OtherIsConst, T> &) noexcept [with IsConst=true, T=Vector3, OtherIsConst=false]" at line 122 of /home/ps/Projects/muda/src/muda/compute_graph/compute_graph_var.h
            instantiation of "muda::ComputeGraphVar<T>::ROViewer muda::ComputeGraphVar<T>::ceval() const [with T=muda::Dense1DT<false, Vector3>]" at line 35 of /home/ps/Projects/muda/test/unit_test/[compute_graph_test.cu](http://compute_graph_test.cu/)
```